### PR TITLE
Fix: Enable Parallel Read Access in files of LoadNetwork method

### DIFF
--- a/src/MGroup.MachineLearning.TensorFlow/NeuralNetworks/Autoencoder.cs
+++ b/src/MGroup.MachineLearning.TensorFlow/NeuralNetworks/Autoencoder.cs
@@ -214,14 +214,14 @@ namespace MGroup.MachineLearning.TensorFlow.NeuralNetworks
 
 		public void LoadNetwork(string netPath, string weightsPath, string normalizationPath)
 		{
-			using (Stream stream = File.Open(normalizationPath, FileMode.Open))
+			using (Stream stream = File.Open(normalizationPath, FileMode.Open, FileAccess.Read, FileShare.Read))
 			{
 				var binaryFormatter = new System.Runtime.Serialization.Formatters.Binary.BinaryFormatter();
 				var Normalization = (INormalization[])binaryFormatter.Deserialize(stream);
 				NormalizationX = Normalization[0];
 			}
 
-			using (Stream stream = File.Open(netPath, FileMode.Open))
+			using (Stream stream = File.Open(netPath, FileMode.Open, FileAccess.Read, FileShare.Read))
 			{
 				var binaryFormatter = new System.Runtime.Serialization.Formatters.Binary.BinaryFormatter();
 				AutoencoderLayer = (INetworkLayer[])binaryFormatter.Deserialize(stream);

--- a/src/MGroup.MachineLearning.TensorFlow/NeuralNetworks/ConvolutionalAutoencoder.cs
+++ b/src/MGroup.MachineLearning.TensorFlow/NeuralNetworks/ConvolutionalAutoencoder.cs
@@ -324,14 +324,14 @@ namespace MGroup.MachineLearning.TensorFlow.NeuralNetworks
 
 		public void LoadNetwork(string netPath, string weightsPath, string normalizationPath)
 		{
-			using (Stream stream = File.Open(normalizationPath, FileMode.Open))
+			using (Stream stream = File.Open(normalizationPath, FileMode.Open, FileAccess.Read, FileShare.Read))
 			{
 				var binaryFormatter = new System.Runtime.Serialization.Formatters.Binary.BinaryFormatter();
 				var normalization = (INormalization[])binaryFormatter.Deserialize(stream);
 				Normalization = normalization[0];
 			}
 
-			using (Stream stream = File.Open(netPath, FileMode.Open))
+			using (Stream stream = File.Open(netPath, FileMode.Open, FileAccess.Read, FileShare.Read))
 			{
 				var binaryFormatter = new System.Runtime.Serialization.Formatters.Binary.BinaryFormatter();
 				AutoencoderLayer = (INetworkLayer[])binaryFormatter.Deserialize(stream);

--- a/src/MGroup.MachineLearning.TensorFlow/NeuralNetworks/ConvolutionalNeuralNetwork.cs
+++ b/src/MGroup.MachineLearning.TensorFlow/NeuralNetworks/ConvolutionalNeuralNetwork.cs
@@ -247,7 +247,7 @@ namespace MGroup.MachineLearning.TensorFlow.NeuralNetworks
 
 		public void LoadNetwork(string netPath, string weightsPath, string normalizationPath)
 		{
-			using (Stream stream = File.Open(normalizationPath, FileMode.Open))
+			using (Stream stream = File.Open(normalizationPath, FileMode.Open, FileAccess.Read, FileShare.Read))
 			{
 				var binaryFormatter = new System.Runtime.Serialization.Formatters.Binary.BinaryFormatter();
 				var Normalization = (INormalization[])binaryFormatter.Deserialize(stream);
@@ -255,7 +255,7 @@ namespace MGroup.MachineLearning.TensorFlow.NeuralNetworks
 				NormalizationY = Normalization[1];
 			}
 
-			using (Stream stream = File.Open(netPath, FileMode.Open))
+			using (Stream stream = File.Open(netPath, FileMode.Open, FileAccess.Read, FileShare.Read))
 			{
 				var binaryFormatter = new System.Runtime.Serialization.Formatters.Binary.BinaryFormatter();
 				NeuralNetworkLayer = (INetworkLayer[])binaryFormatter.Deserialize(stream);

--- a/src/MGroup.MachineLearning.TensorFlow/NeuralNetworks/FeedForwardNeuralNetwork.cs
+++ b/src/MGroup.MachineLearning.TensorFlow/NeuralNetworks/FeedForwardNeuralNetwork.cs
@@ -178,7 +178,7 @@ namespace MGroup.MachineLearning.TensorFlow.NeuralNetworks
 
 		public void LoadNetwork(string netPath, string weightsPath, string normalizationPath)
 		{
-			using (Stream stream = File.Open(normalizationPath, FileMode.Open))
+			using (Stream stream = File.Open(normalizationPath, FileMode.Open, FileAccess.Read, FileShare.Read))
 			{
 				var binaryFormatter = new System.Runtime.Serialization.Formatters.Binary.BinaryFormatter();
 				var Normalization = (INormalization[])binaryFormatter.Deserialize(stream);
@@ -186,7 +186,7 @@ namespace MGroup.MachineLearning.TensorFlow.NeuralNetworks
 				NormalizationY = Normalization[1];
 			}
 
-			using (Stream stream = File.Open(netPath, FileMode.Open))
+			using (Stream stream = File.Open(netPath, FileMode.Open, FileAccess.Read, FileShare.Read))
 			{
 				var binaryFormatter = new System.Runtime.Serialization.Formatters.Binary.BinaryFormatter();
 				NeuralNetworkLayer = (INetworkLayer[])binaryFormatter.Deserialize(stream);


### PR DESCRIPTION
- Updated `LoadNetwork` method to use `File.Open` with `FileShare.Read` to allow multiple threads to read the network and normalization files concurrently.
- Fixed issue where multiple processes couldn't access same file throwing file access error